### PR TITLE
Revert "add Verilog solidity puzzles"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "solidity-puzzles"]
-	path = solidity-puzzles
-	url = https://github.com/Verilog-Solutions/solidity-puzzles


### PR DESCRIPTION
Reverts ryestew/gamedayRemix#4
Because Remix dgit plugin cannot handle git submodule feature